### PR TITLE
build: improve installation script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
+prefix ?= /usr/local
+bindir = $(prefix)/bin
+
 install:
 	cp terminal/.bash_profile ~/.bash_profile
 	cp terminal/.bash_profile ~/.oh-my-zsh/custom/mick-custo-READONLY.zsh
+
+	install git/git-catchup "$(bindir)/git-catchup"
+	install git/git-commit-workflow "$(bindir)/git-commit-workflow"
+	install git/git-readme "$(bindir)/git-readme"
+
 	./git/install-gitconfig
-	ln -f -s `pwd`/git/git-catchup ~/bin/
-	ln -f -s `pwd`/git/git-commit-workflow ~/bin/
-	ln -f -s `pwd`/git/git-readme ~/bin/

--- a/git/git-catchup
+++ b/git/git-catchup
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash -e
 # No -x as I don't want to see the command output
 
+# Get back to master
 git checkout master
+
+# Fetch things from the upstream, including tags
 git pull upstream master --tags
+
+# Push things back to the origin fork
 git push origin master
+
+# Prune things up
 git remote prune origin
+git cleanup


### PR DESCRIPTION
When switching to a secondary laptop, I realized running `make install` would fail.
This PR tries to normalize a little the installation script so that it can work on any macOS machine.