### PR TITLE
Fix git-readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,6 @@ install:
 	install git/git-readme "$(bindir)/git-readme"
 
 	./git/install-gitconfig
+
+open: 
+	open -a 'Visual Studio Code'

--- a/git/git-readme
+++ b/git/git-readme
@@ -7,10 +7,10 @@ GIT_ROOT_DIR=`git rev-parse --show-toplevel`
 README="${GIT_ROOT_DIR}/README"
 README_MD="${GIT_ROOT_DIR}/README.md"
 
-if [ -f $README ]; then
-  open -b $MARKDOWN_APP_BUNDLE_ID $README
-elif [ -f $README_MD ]; then
-  open -b $MARKDOWN_APP_BUNDLE_ID $README_MD
+if [ -f "$README" ]; then
+  open -b $MARKDOWN_APP_BUNDLE_ID "$README"
+elif [ -f "$README_MD" ]; then
+  open -b $MARKDOWN_APP_BUNDLE_ID "$README_MD"
 else
   echo "No README or README.md file found."
   exit 1


### PR DESCRIPTION
The script wouldn't work when the working copy's path would contain space characters.
This PR fixes that.