### PR TITLE
Add fixlint Git command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ install:
 
 	install git/git-catchup "$(bindir)/git-catchup"
 	install git/git-commit-workflow "$(bindir)/git-commit-workflow"
+	install git/git-fix-lint "$(bindir)/git-fix-lint"
 	install git/git-readme "$(bindir)/git-readme"
 
 	./git/install-gitconfig

--- a/git/git-fix-lint.rb
+++ b/git/git-fix-lint.rb
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+def parse_working_tree_item(str)
+  /^(?<X>[ MADRCU\?])(?<Y>[ MADRCU\?])\s(?<PATH>.*)$/m.match(str.rstrip)
+end
+
+def supported?(parsed_item)
+  return [false, 'item could not be parsed'] if parsed_item.nil?
+  return [false, "unsupported X: #{parsed_item[:X]}"] unless parsed_item[:X] == ' '
+  return [false, "unsupported Y: #{parsed_item[:Y]}"] unless parsed_item[:Y] == 'M'
+
+  [true, parsed_item[:PATH]]
+end
+
+def latest_commit(filename)
+  [`git rev-list -1 HEAD #{filename}`.strip, filename]
+end
+
+def fixup_script(commit, filename)
+  res = <<~SCRIPT
+    git add #{filename}
+    git commit --fixup #{commit}
+  SCRIPT
+
+  res
+end
+
+def run(command)
+  return if system(command)
+
+  error_message = "Command #{command} failed"
+  raise error_message
+end
+
+# This will output something like
+# XY PATH
+# Cf. https://git-scm.com/docs/git-status#_output
+working_tree = `git status --porcelain`
+
+working_tree
+  .lines
+  .map { |item| parse_working_tree_item(item) }
+  .map { |item| supported?(item) }
+  .select { |item| item[0] == true }
+  .map { |item| item[1] }
+  .map { |item| latest_commit(item) }
+  .map { |item| fixup_script(item[0], item[1]) }
+  .each { |item| run(item) }


### PR DESCRIPTION
This command is useful when running a linter a little too late. For each file that is being linted
in the working tree, it will fixup its latest commit to minimize the number of linting commits.